### PR TITLE
Fix authentication persistence after tab switching (#1428)

### DIFF
--- a/tests/auth-session-persistence.spec.ts
+++ b/tests/auth-session-persistence.spec.ts
@@ -1,0 +1,203 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '../pages/api/v1/auth';
+import { supabaseService } from '../data/supabaseService';
+
+// Mock the supabaseService
+jest.mock('../data/supabaseService', () => ({
+  supabaseService: {
+    signInWithEmail: jest.fn(),
+    signOut: jest.fn(),
+    getCurrentUser: jest.fn(),
+    refreshSession: jest.fn(),
+  },
+}));
+
+describe('Auth Session Persistence Issue #1428', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Session validation after tab switching', () => {
+    it('should maintain valid session when user returns to tab with valid JWT', async () => {
+      const mockUser = {
+        id: 'user123',
+        email: 'test@example.com',
+      };
+
+      // Mock getCurrentUser to return valid user (simulating valid JWT)
+      (supabaseService.getCurrentUser as jest.Mock).mockResolvedValueOnce(
+        mockUser,
+      );
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        cookies: {
+          auth_session: JSON.stringify({
+            userId: 'user123',
+            createdAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+          }),
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.data.id).toBe(mockUser.id);
+      expect(responseData.error).toBeNull();
+    });
+
+    it('should return 401 when JWT is invalid but cookie exists', async () => {
+      // Mock getCurrentUser to throw error (simulating invalid JWT)
+      (supabaseService.getCurrentUser as jest.Mock).mockRejectedValueOnce(
+        new Error('Invalid JWT'),
+      );
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        cookies: {
+          auth_session: JSON.stringify({
+            userId: 'user123',
+            createdAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+          }),
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.data).toBeNull();
+      expect(responseData.error).toBeTruthy();
+    });
+
+    it('should handle session refresh when JWT is expired but refresh token is valid', async () => {
+      const mockUser = {
+        id: 'user123',
+        email: 'test@example.com',
+      };
+
+      // Mock refreshSession to return valid user
+      (supabaseService.refreshSession as jest.Mock).mockResolvedValueOnce({
+        user: mockUser,
+        session: { access_token: 'new-token' },
+      });
+
+      const { req, res } = createMocks({
+        method: 'PUT',
+        cookies: {
+          auth_session: JSON.stringify({
+            userId: 'user123',
+            createdAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+          }),
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.data.id).toBe(mockUser.id);
+      expect(responseData.error).toBeNull();
+
+      // Check that a new cookie was set with updated timestamp
+      const setCookieHeader = res.getHeader('Set-Cookie');
+      expect(setCookieHeader).toBeDefined();
+      expect(typeof setCookieHeader).toBe('string');
+
+      const cookieString = setCookieHeader as string;
+      expect(cookieString).toContain('user123');
+    });
+
+    it('should return 401 when both JWT and refresh token are invalid', async () => {
+      // Mock refreshSession to throw error (simulating invalid refresh token)
+      (supabaseService.refreshSession as jest.Mock).mockRejectedValueOnce(
+        new Error('Invalid refresh token'),
+      );
+
+      const { req, res } = createMocks({
+        method: 'PUT',
+        cookies: {
+          auth_session: JSON.stringify({
+            userId: 'user123',
+            createdAt: Date.now() - 15 * 24 * 60 * 60 * 1000, // 15 days ago (expired)
+          }),
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.data).toBeNull();
+      expect(responseData.error).toBe('Invalid refresh token');
+    });
+  });
+
+  describe('Cookie malformation issues', () => {
+    it('should handle malformed session cookies gracefully', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        cookies: {
+          auth_session: 'malformed-json-string',
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.error).toBe('Invalid session cookie format');
+      expect(responseData.data).toBeNull();
+    });
+
+    it('should handle missing userId in cookie', async () => {
+      const { req, res } = createMocks({
+        method: 'GET',
+        cookies: {
+          auth_session: JSON.stringify({
+            // Missing userId
+            createdAt: Date.now(),
+          }),
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.error).toBe('Invalid session cookie');
+      expect(responseData.data).toBeNull();
+    });
+  });
+
+  describe('Session mismatch scenarios', () => {
+    it('should detect and reject session when cookie userId does not match Supabase user', async () => {
+      const mockUser = {
+        id: 'different-user-id', // Different from cookie
+        email: 'test@example.com',
+      };
+
+      (supabaseService.getCurrentUser as jest.Mock).mockResolvedValueOnce(
+        mockUser,
+      );
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        cookies: {
+          auth_session: JSON.stringify({
+            userId: 'user123', // Different from mockUser.id
+            createdAt: Date.now(),
+          }),
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      const responseData = JSON.parse(res._getData());
+      expect(responseData.error).toBe('Session user mismatch');
+      expect(responseData.data).toBeNull();
+    });
+  });
+});

--- a/tests/auth-visibility-handling.spec.tsx
+++ b/tests/auth-visibility-handling.spec.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import { AuthProvider, useAuth } from '../services/auth';
+
+// Mock next/router
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+// Mock fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Test component that uses the auth context
+const TestComponent: React.FC = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) return <div>Loading...</div>;
+  if (user) return <div>Authenticated as {user.email}</div>;
+  return <div>Not authenticated</div>;
+};
+
+describe('AuthProvider Visibility Change Handling', () => {
+  const mockRouterPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockRouterPush,
+    });
+
+    // Mock successful initial auth check
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: 'user123',
+          email: 'test@example.com',
+        },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    // Clear any pending timers
+    jest.clearAllTimers();
+  });
+
+  it('should re-validate session when user returns to visible tab', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    // Wait for initial auth check
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authenticated as test@example.com'),
+      ).toBeInTheDocument();
+    });
+
+    // Clear the initial fetch call
+    mockFetch.mockClear();
+
+    // Mock successful session validation
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: 'user123',
+          email: 'test@example.com',
+        },
+      }),
+    });
+
+    // Simulate user switching away from tab
+    Object.defineProperty(document, 'hidden', {
+      writable: true,
+      value: true,
+    });
+
+    // Simulate user returning to tab
+    Object.defineProperty(document, 'hidden', {
+      writable: true,
+      value: false,
+    });
+
+    // Trigger visibility change event
+    const visibilityChangeEvent = new Event('visibilitychange');
+    document.dispatchEvent(visibilityChangeEvent);
+
+    // Wait for session validation
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/auth');
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('should clear user session when validation fails on visibility change', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    // Wait for initial auth check
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authenticated as test@example.com'),
+      ).toBeInTheDocument();
+    });
+
+    // Clear the initial fetch call
+    mockFetch.mockClear();
+
+    // Mock failed session validation (e.g., session expired)
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    // Simulate user returning to tab
+    Object.defineProperty(document, 'hidden', {
+      writable: true,
+      value: false,
+    });
+
+    // Trigger visibility change event
+    const visibilityChangeEvent = new Event('visibilitychange');
+    document.dispatchEvent(visibilityChangeEvent);
+
+    // Wait for session validation and user state update
+    await waitFor(() => {
+      expect(screen.getByText('Not authenticated')).toBeInTheDocument();
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('should refresh session when needsRefresh flag is set', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    // Wait for initial auth check
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authenticated as test@example.com'),
+      ).toBeInTheDocument();
+    });
+
+    // Clear the initial fetch call
+    mockFetch.mockClear();
+
+    // Mock session validation with needsRefresh flag
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: 'user123',
+          email: 'test@example.com',
+          needsRefresh: true,
+        },
+      }),
+    });
+
+    // Mock successful session refresh
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: 'user123',
+          email: 'test@example.com',
+        },
+      }),
+    });
+
+    // Simulate user returning to tab
+    Object.defineProperty(document, 'hidden', {
+      writable: true,
+      value: false,
+    });
+
+    // Trigger visibility change event
+    const visibilityChangeEvent = new Event('visibilitychange');
+    document.dispatchEvent(visibilityChangeEvent);
+
+    // Wait for session validation and refresh
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    // Check that refresh was called with PUT method
+    expect(mockFetch).toHaveBeenNthCalledWith(1, '/api/v1/auth');
+    expect(mockFetch).toHaveBeenNthCalledWith(2, '/api/v1/auth', {
+      method: 'PUT',
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('should validate session periodically when tab is visible', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    // Wait for initial auth check
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authenticated as test@example.com'),
+      ).toBeInTheDocument();
+    });
+
+    // Clear the initial fetch call
+    mockFetch.mockClear();
+
+    // Mock successful periodic validation
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: 'user123',
+          email: 'test@example.com',
+        },
+      }),
+    });
+
+    // Ensure tab is visible
+    Object.defineProperty(document, 'hidden', {
+      writable: true,
+      value: false,
+    });
+
+    // Fast-forward 5 minutes to trigger periodic validation
+    jest.advanceTimersByTime(5 * 60 * 1000);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/v1/auth');
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('should not validate when tab is hidden during periodic check', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>,
+    );
+
+    // Wait for initial auth check
+    await waitFor(() => {
+      expect(
+        screen.getByText('Authenticated as test@example.com'),
+      ).toBeInTheDocument();
+    });
+
+    // Clear the initial fetch call
+    mockFetch.mockClear();
+
+    // Ensure tab is hidden
+    Object.defineProperty(document, 'hidden', {
+      writable: true,
+      value: true,
+    });
+
+    // Fast-forward 5 minutes
+    jest.advanceTimersByTime(5 * 60 * 1000);
+
+    // Should not have made any validation calls since tab is hidden
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes authentication issue where users were asked to re-authenticate after switching tabs and returning to the app
- Implements session re-validation using Page Visibility API when users return to tabs
- Adds periodic session validation every 5 minutes when tab is active
- Improves session refresh handling with proper error handling

## Root Cause
The original authentication system only validated user sessions once on component mount. When users switched browser tabs and returned, there was no mechanism to re-validate their session, causing the app to lose track of authentication state even when the server-side session was still valid.

## Solution
1. **Page Visibility API Integration**: Automatically re-validates authentication when users return to the tab
2. **Periodic Validation**: Validates session every 5 minutes when tab is active to catch expiration
3. **Improved Architecture**: Uses useCallback and useRef patterns to prevent unnecessary re-registrations
4. **Enhanced Error Handling**: Properly handles session refresh failures and network issues

## Test Plan
- [x] Added comprehensive tests for tab switching scenarios
- [x] Added tests for session expiration handling
- [x] Added tests for cookie malformation and security scenarios
- [x] All existing tests pass
- [x] TypeScript compilation passes
- [x] Linting passes

## Technical Details
- Uses `document.visibilitychange` event to detect tab returns
- Maintains existing cookie-based authentication with dual validation (cookie + JWT)
- Preserves backward compatibility
- Works correctly in serverless deployment environments

🤖 Generated with [Claude Code](https://claude.ai/code)